### PR TITLE
feat: --dump-src passes shellcheck

### DIFF
--- a/blarg
+++ b/blarg
@@ -12,7 +12,7 @@ from tempfile import TemporaryDirectory
 from typing import List, Optional
 
 
-VERSION = "0.1.0"
+VERSION = "0.1.1"
 
 
 STDLIB = """

--- a/blarg
+++ b/blarg
@@ -50,10 +50,18 @@ apply_target() {
 BASE = """
 
 reached_if() {
+    # this command will normally be unreachable; the user's `reached_if` implementation will
+    # very often override this one.
+    #
+    # shellcheck disable=SC2317
     false
 }
 
 apply() {
+    # this command will normally be unreachable; the user's `apply` implementation will
+    # very often override this one.
+    #
+    # shellcheck disable=SC2317
     true
 }
 

--- a/tests/all_tests.bats
+++ b/tests/all_tests.bats
@@ -223,9 +223,18 @@ hi
 }
 
 @test 'dump-src - always - passes shellcheck' {
-    use_target complete
-    blarg --dump-src targets/complete.bash > dump.sh
-    shellcheck dump.sh
+    local targets=(
+        complete
+        basic
+        simple_apply
+        empty
+        nested_deps
+    )
+    use_target "${targets[@]}"
+    for t in "${targets[@]}"; do
+        blarg --dump-src "targets/${t}.bash" > "${t}_dump.sh"
+    done
+    shellcheck ./*_dump.sh
 }
 
 @test 'reached_if - returns true - still applies dependencies' {

--- a/tests/all_tests.bats
+++ b/tests/all_tests.bats
@@ -222,6 +222,12 @@ hi
     assert_stdout '^#!/usr/bin/env bash'
 }
 
+@test 'dump-src - always - passes shellcheck' {
+    use_target complete
+    blarg --dump-src targets/complete.bash > dump.sh
+    shellcheck dump.sh
+}
+
 @test 'reached_if - returns true - still applies dependencies' {
     use_target reached_if_true_with_deps foobar
     capture_output blarg --verbose ./targets/reached_if_true_with_deps.bash

--- a/tests/targets/complete.bash
+++ b/tests/targets/complete.bash
@@ -1,0 +1,14 @@
+#!/usr/bin/env blarg
+# an example usage of all built-in features
+
+depends_on foobar
+
+reached_if() {
+    false
+}
+
+apply() {
+    log_verbose "applying..."
+    apply_target basic
+    this_command_doesnt_exist_934hfnn || panic "Oops!"
+}


### PR DESCRIPTION
if you run `shellcheck` against the script generated by `--dump-src`, it should report no lint.

* ignore a couple shellcheck warnings in the output script
* add a test to make sure the output script stays clean
