### PR TITLE
fix: exit code handling

### DIFF
--- a/blarg
+++ b/blarg
@@ -104,7 +104,7 @@ __BLARG_MAIN__() {
                 apply
             )
             apply_result=$?
-            test ${apply_result} -eq 0 || return ${apply_result}
+            test ${apply_result} -eq 0 || panic "${BLARG_TARGET_NAME}.apply() returned with code ${apply_result}."
         fi
         log_verbose "${BLARG_INDENT}${BLARG_TARGET_NAME} [done]"
     else

--- a/blarg
+++ b/blarg
@@ -81,7 +81,7 @@ EXECUTOR = """
 __BLARG_MAIN__() {
     if [ ${#BLARG_TARGET_DEPENDENCIES[@]} -gt 0 ]; then
         log_verbose "${BLARG_INDENT}${BLARG_TARGET_NAME} [dependencies...]"
-        satisfy "${BLARG_TARGET_DEPENDENCIES[@]}" || exit $?
+        satisfy "${BLARG_TARGET_DEPENDENCIES[@]}" || return $?
     fi
 
     log_verbose "${BLARG_INDENT}${BLARG_TARGET_NAME} [running...]"
@@ -98,7 +98,7 @@ __BLARG_MAIN__() {
             (
                 set -Eeuo pipefail
                 apply
-            ) || exit $?
+            ) || return $?
         fi
         log_verbose "${BLARG_INDENT}${BLARG_TARGET_NAME} [done]"
     else

--- a/blarg
+++ b/blarg
@@ -32,6 +32,10 @@ log_verbose() {
 }
 
 depends_on() {
+    # this command may not be used in the user's target script, so we could get
+    # a shellcheck "command unreachable" error here _sometimes_.
+    #
+    # shellcheck disable=SC2317
     BLARG_TARGET_DEPENDENCIES+=("$@")
 }
 
@@ -51,7 +55,7 @@ satisfy() {
         done
         test -f "${full_target_path}" \\
             || panic "Target does not exist: ${script_basename}"
-        "${full_target_path}" || exit $?
+        "${full_target_path}" || return $?
     done
 }
 """
@@ -98,7 +102,9 @@ __BLARG_MAIN__() {
             (
                 set -Eeuo pipefail
                 apply
-            ) || return $?
+            )
+            apply_result=$?
+            test ${apply_result} -eq 0 || return ${apply_result}
         fi
         log_verbose "${BLARG_INDENT}${BLARG_TARGET_NAME} [done]"
     else

--- a/blarg
+++ b/blarg
@@ -12,7 +12,7 @@ from tempfile import TemporaryDirectory
 from typing import List, Optional
 
 
-VERSION = "0.4.1"
+VERSION = "0.4.2"
 
 
 STDLIB = """

--- a/tests/all_tests.bats
+++ b/tests/all_tests.bats
@@ -65,7 +65,8 @@ B!$'
 @test 'panic - always - crashes script' {
     use_target panic
     capture_output ./targets/panic.bash
-    assert_stderr '^FATAL: OMG panic!$'
+    assert_stderr '^FATAL: OMG panic!
+FATAL: panic\.apply\(\) returned with code 1\.$'
     assert_exit_code 1
     assert_no_stdout
 }
@@ -207,7 +208,9 @@ B!
 hi
  --> satisfied_if_false \[done\]
  --> panic \[running\.\.\.\]$'
-    assert_stderr '^FATAL: OMG panic!$'
+    assert_stderr '^FATAL: OMG panic!
+FATAL: panic\.apply\(\) returned with code 1\.
+FATAL: satisfy\.apply\(\) returned with code 1\.$'
 }
 
 @test 'satisfy - target doesnt exist - fails' {
@@ -223,7 +226,9 @@ hi
     capture_output ./targets/satisfy_fails.bash
     assert_no_stdout
     assert_exit_code 1
-    assert_stderr '^FATAL: OMG panic!$'
+    assert_stderr '^FATAL: OMG panic!
+FATAL: panic\.apply\(\) returned with code 1\.
+FATAL: satisfy_fails\.apply\(\) returned with code 1\.$'
 }
 
 @test 'dump-src - always - begins with shebang' {
@@ -338,6 +343,6 @@ dry-run: would apply run_once_b$'
     use_target apply_non_zero_exit
     capture_output blarg ./targets/apply_non_zero_exit.bash
     assert_no_stdout
-    assert_no_stderr
+    assert_stderr '^FATAL: apply_non_zero_exit\.apply\(\) returned with code 1\.$'
     assert_exit_code 1
 }

--- a/tests/all_tests.bats
+++ b/tests/all_tests.bats
@@ -221,9 +221,9 @@ hi
 @test 'satisfy - target fails - fails' {
     use_target panic satisfy_fails
     capture_output ./targets/satisfy_fails.bash
+    assert_no_stdout
     assert_exit_code 1
     assert_stderr '^FATAL: OMG panic!$'
-    assert_no_stdout
 }
 
 @test 'dump-src - always - begins with shebang' {
@@ -332,4 +332,12 @@ hello, there\.\.\.
     assert_stdout '^dry-run: would apply should_run_once
 dry-run: would apply run_once_a
 dry-run: would apply run_once_b$'
+}
+
+@test 'apply - non-zero command exit - exits immediately' {
+    use_target apply_non_zero_exit
+    capture_output blarg ./targets/apply_non_zero_exit.bash
+    assert_no_stdout
+    assert_no_stderr
+    assert_exit_code 1
 }

--- a/tests/targets/apply_non_zero_exit.bash
+++ b/tests/targets/apply_non_zero_exit.bash
@@ -1,0 +1,4 @@
+apply() {
+    false # this is different from calling `panic` because `panic` calls `exit` explicitly
+    echo "You shouldn't see this"
+}


### PR DESCRIPTION
The problem with using `exit` instead of `return` is it hides the fact that your error handling isn't working correctly. Especially in the context of `set -e`.

If you do the hard work of making your functions return a non-zero exit code all the way up the chain back to the entrypoint of your script, and your script exits the way you expect, then everything's gravy.

However if you just `exit` from anywhere in your script, then 99% of the time you'll crash your script as expected, but you might be hiding the fact that _other_ commands that have non-zero exit codes are _not_ crashing your script as you expect.

In this PR, I replace a few `exit` statements with `return`, and in the process revealed a bug that allowed `apply` to fail ONLY if you explicitly call `panic` or `exit 1`. Before this change, `apply` would not fail if, for example, you ran the `false` command.

- **chore: make __BLARG_MAIN__ use return instead of exit**
- **fix `apply` return handling**
- **more useful output after an apply failure**
