### PR TITLE
external modules

### DIFF
--- a/blarg
+++ b/blarg
@@ -295,17 +295,21 @@ class BlargConfig:
 
 
 def parse_config(config_path: Path) -> BlargConfig:
+    ALLOWED_MODULE_NAME_CHARS = set("abcdefghijklmnopqrstuvwxyz_0123456789")
     config = ConfigParser()
     config.read(config_path)
 
     modules: List[ExternalModule] = []
     section: str
     for section in config.sections():
-        (_, _, module_id) = section.partition(
-            "module."
-        )  # TODO: restrict valid chars like `/`
+        (_, _, module_id) = section.partition("module.")
         if module_id == "":
             continue
+
+        if len(set(module_id).difference(ALLOWED_MODULE_NAME_CHARS)) > 0:
+            raise ValueError(
+                f"Invalid module ID: `{module_id}`. Module IDs can only contain lowercase characters, underscores, and numbers."
+            )
 
         modules.append(
             ExternalModule(

--- a/blarg
+++ b/blarg
@@ -45,11 +45,26 @@ depends_on() {
     BLARG_TARGET_DEPENDENCIES+=("$@")
 }
 
+is_external_module_target() {
+    [[ "${1}" =~ ^@([a-zA-Z0-9_-]+):(.+)$ ]]
+}
+
+get_module_dir() {
+    local script_basename="${1}"
+    if is_external_module_target "${script_basename}"; then
+        module_name="${BASH_REMATCH[1]}"
+        module_env="BLARG_MODULE_${module_name}"
+        echo "${!module_env}"
+    else
+        echo "${BLARG_MODULE_DIR}"
+    fi
+}
+
 find_target() {
     local script_basename="${1}"
     local module_name module_env this_dir full_target_path search_dirs script_basename dir
 
-    if [[ "${script_basename}" =~ ^@([a-zA-Z0-9_-]+):(.+)$ ]]; then
+    if is_external_module_target "${script_basename}"; then
         module_name="${BASH_REMATCH[1]}"
         script_basename="${BASH_REMATCH[2]}"
         module_env="BLARG_MODULE_${module_name}"
@@ -77,9 +92,13 @@ satisfy() {
 
     final_result=0
     for script_basename in "$@"; do
+
         full_target_path="$(find_target "${script_basename}")" \\
             || panic "Target does not exist: ${script_basename}"
-        "${full_target_path}"
+
+        BLARG_MODULE_DIR="$(get_module_dir "${script_basename}")" \\
+            "${full_target_path}"
+
         target_result=$?
         if [ ${target_result} -ne 0 ]; then
             if is_dry_run; then
@@ -332,6 +351,11 @@ def main() -> int:
 
     if not env.get("BLARG_CWD"):
         env["BLARG_CWD"] = str(working_dir)
+
+    if not env.get(
+        "BLARG_MODULE_DIR"
+    ):  # TODO: document difference between module dir and CWD
+        env["BLARG_MODULE_DIR"] = str(working_dir)
 
     targets_dir = env.get("BLARG_TARGETS_DIR")
     if targets_dir:

--- a/blarg
+++ b/blarg
@@ -6,8 +6,10 @@ import os
 import subprocess
 import sys
 
+from configparser import ConfigParser
 from dataclasses import dataclass
 from pathlib import Path
+from shutil import rmtree
 from tempfile import TemporaryDirectory
 from typing import List, Optional
 
@@ -45,12 +47,20 @@ depends_on() {
 
 find_target() {
     local script_basename="${1}"
-    local this_dir full_target_path search_dirs script_basename dir
-    this_dir="$(dirname "${BLARG_TARGET_PATH}")" || panic "unable to get directory name"
-    search_dirs=(
-        "${this_dir}"
-        "${BLARG_TARGETS_DIR}"
-    )
+    local module_name module_env this_dir full_target_path search_dirs script_basename dir
+
+    if [[ "${script_basename}" =~ ^@([a-zA-Z0-9_-]+):(.+)$ ]]; then
+        module_name="${BASH_REMATCH[1]}"
+        script_basename="${BASH_REMATCH[2]}"
+        module_env="BLARG_MODULE_${module_name}"
+        search_dirs=("${!module_env}")
+    else
+        this_dir="$(dirname "${BLARG_TARGET_PATH}")" || panic "unable to get directory name"
+        search_dirs=(
+            "${this_dir}"
+            "${BLARG_TARGETS_DIR}"
+        )
+    fi
 
     for dir in "${search_dirs[@]}"; do
         full_target_path="${dir}/${script_basename}.bash"
@@ -227,6 +237,65 @@ def generate_script(script_path: Path) -> str:
     return "".join(script_parts + [BASE, script, EXECUTOR]).lstrip()
 
 
+@dataclass
+class ExternalModule:
+    id: str
+    location: str
+    ref: str
+
+    def init(self, working_dir: Path) -> Path:
+        module_dir = working_dir / ".blarg" / "modules" / self.id / self.ref
+        module_dir.mkdir(parents=True, exist_ok=True)
+
+        if not (module_dir / ".git").exists():
+            try:
+                subprocess.run(
+                    [
+                        "git",
+                        "clone",
+                        "--depth",
+                        "1",
+                        "--branch",
+                        self.ref,
+                        self.location,
+                        module_dir,
+                    ],
+                    check=True,
+                )
+            except:
+                rmtree(module_dir)
+                raise
+        return module_dir
+
+
+@dataclass
+class BlargConfig:
+    modules: List[ExternalModule]
+
+
+def parse_config(config_path: Path) -> BlargConfig:
+    config = ConfigParser()
+    config.read(config_path)
+
+    modules: List[ExternalModule] = []
+    section: str
+    for section in config.sections():
+        (_, _, module_id) = section.partition(
+            "module."
+        )  # TODO: restrict valid chars like `/`
+        if module_id == "":
+            continue
+
+        modules.append(
+            ExternalModule(
+                module_id,
+                config[section]["location"],
+                config[section]["ref"],  # TODO: restrict valid chars like `/`
+            )
+        )
+    return BlargConfig(modules)
+
+
 def main() -> int:
     args = parse_args()
 
@@ -247,6 +316,13 @@ def main() -> int:
         return 0
 
     env = os.environ
+    working_dir = Path(os.getcwd())
+
+    config = parse_config(Path("blarg.conf"))
+    for module in config.modules:
+        module_dir = module.init(working_dir)
+        env[f"BLARG_MODULE_{module.id}"] = str(module_dir)
+
     resolved_path = script_path.resolve()
     env["BLARG_TARGET_PATH"] = str(resolved_path)
 
@@ -255,7 +331,7 @@ def main() -> int:
         env["BLARG_VERBOSE"] = str(is_verbose)
 
     if not env.get("BLARG_CWD"):
-        env["BLARG_CWD"] = os.getcwd()
+        env["BLARG_CWD"] = str(working_dir)
 
     targets_dir = env.get("BLARG_TARGETS_DIR")
     if targets_dir:

--- a/blarg
+++ b/blarg
@@ -69,7 +69,11 @@ find_target() {
         module_name="${BASH_REMATCH[1]}"
         script_basename="${BASH_REMATCH[2]}"
         module_env="BLARG_MODULE_${module_name}"
-        search_dirs=("${!module_env}/targets")
+        if [ "${!module_env:-}" == "" ]; then
+            search_dirs=()
+        else
+            search_dirs=("${!module_env}/targets")
+        fi
     else
         this_dir="$(dirname "${BLARG_TARGET_PATH}")" || panic "unable to get directory name"
         search_dirs=(

--- a/blarg
+++ b/blarg
@@ -271,9 +271,22 @@ class ExternalModule:
 
     def init(self, working_dir: Path) -> Path:
         # `self.ref` could have some dangerous characters in it for file paths. let's
-        # instead use a sha1 hash of `self.ref` when figuring out where to store this
-        # external module locally.
-        ref_dir_name = hashlib.sha1(self.ref.encode("utf8")).hexdigest()[:12]
+        # use an allowlist of known-safe characters, and replace everything else with
+        # an underscore.
+        #
+        # if this ever gets ported to work on Windows, it needs to be adapted to account
+        # for reserved file names as well.
+        ALLOWED_REF_DIR_CHARS = set(
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_-0123456789"
+        )
+        sanitized_ref_chars: list[str] = []
+        for ch in self.ref:
+            if ch in ALLOWED_REF_DIR_CHARS:
+                sanitized_ref_chars.append(ch)
+            else:
+                sanitized_ref_chars.append("_")
+        ref_dir_name = "".join(sanitized_ref_chars)
+
         module_dir = working_dir / ".blarg" / "modules" / self.id / ref_dir_name
 
         if not (module_dir / ".git").exists():
@@ -380,7 +393,7 @@ def main() -> int:
     if targets_dir:
         targets_dir = Path(targets_dir).resolve()
     else:
-        targets_dir = str(Path.cwd() / "targets")  # FIXME: should load from module dir
+        targets_dir = str(Path.cwd() / "targets")
         env["BLARG_TARGETS_DIR"] = targets_dir
 
     dry_run = args.dry_run or "BLARG_DRY_RUN" in env

--- a/blarg
+++ b/blarg
@@ -357,7 +357,7 @@ def main() -> int:
         print(generate_script(module_dir, script_path))
         return 0
 
-    config = parse_config(Path("blarg.conf"))  # FIXME: should load from module dir
+    config = parse_config(module_dir / "blarg.conf")
     for module in config.modules:
         module_dir = module.init(working_dir)
         env[f"BLARG_MODULE_{module.id}"] = str(module_dir)

--- a/blarg
+++ b/blarg
@@ -245,11 +245,11 @@ def list_dir_if_exists(dir_path: Path) -> List[Path]:
         return []
 
 
-def generate_script(script_path: Path) -> str:
+def generate_script(module_root_dir: Path, script_path: Path) -> str:
     script = f"# {script_path}\n" + script_path.read_text("utf8")
     script_parts = [STDLIB]
 
-    lib_d_dir = Path("lib.d")  # lib.d dir in current working directory
+    lib_d_dir = module_root_dir / "lib.d"
     for file in list_dir_if_exists(lib_d_dir):
         if not str(file).endswith(".sh") and not str(file).endswith(".bash"):
             continue
@@ -340,14 +340,24 @@ def main() -> int:
     if script_path.is_dir():
         script_path = script_path / "main.bash"
 
-    if args.dump_src:
-        print(generate_script(script_path))
-        return 0
-
     env = os.environ
     working_dir = Path(os.getcwd())
 
-    config = parse_config(Path("blarg.conf"))
+    if not env.get("BLARG_CWD"):
+        env["BLARG_CWD"] = str(working_dir)
+
+    module_dir_str = env.get("BLARG_MODULE_DIR")
+    if module_dir_str is None:  # TODO: document difference between module dir and CWD
+        module_dir = working_dir
+        env["BLARG_MODULE_DIR"] = str(module_dir)
+    else:
+        module_dir = Path(module_dir_str)
+
+    if args.dump_src:
+        print(generate_script(module_dir, script_path))
+        return 0
+
+    config = parse_config(Path("blarg.conf"))  # FIXME: should load from module dir
     for module in config.modules:
         module_dir = module.init(working_dir)
         env[f"BLARG_MODULE_{module.id}"] = str(module_dir)
@@ -359,19 +369,11 @@ def main() -> int:
     if is_verbose:
         env["BLARG_VERBOSE"] = str(is_verbose)
 
-    if not env.get("BLARG_CWD"):
-        env["BLARG_CWD"] = str(working_dir)
-
-    if not env.get(
-        "BLARG_MODULE_DIR"
-    ):  # TODO: document difference between module dir and CWD
-        env["BLARG_MODULE_DIR"] = str(working_dir)
-
     targets_dir = env.get("BLARG_TARGETS_DIR")
     if targets_dir:
         targets_dir = Path(targets_dir).resolve()
     else:
-        targets_dir = str(Path.cwd() / "targets")
+        targets_dir = str(Path.cwd() / "targets")  # FIXME: should load from module dir
         env["BLARG_TARGETS_DIR"] = targets_dir
 
     dry_run = args.dry_run or "BLARG_DRY_RUN" in env
@@ -427,7 +429,7 @@ def main() -> int:
     try:
         result = subprocess.run(
             ["bash", "-Euo", "pipefail"],
-            input=generate_script(script_path),
+            input=generate_script(module_dir, script_path),
             encoding="utf8",
             env=env,
         )

--- a/blarg
+++ b/blarg
@@ -14,7 +14,7 @@ from tempfile import TemporaryDirectory
 from typing import List, Optional
 
 
-VERSION = "0.5.2"
+VERSION = "0.6.0"
 
 
 STDLIB = """

--- a/blarg
+++ b/blarg
@@ -3,6 +3,7 @@ import argparse
 import hashlib
 import json
 import os
+import re
 import subprocess
 import sys
 
@@ -273,6 +274,8 @@ class ExternalModule:
 
         if not (module_dir / ".git").exists():
             module_dir.mkdir(parents=True, exist_ok=True)
+            source_dir = re.sub("^file://~", Path.home().as_uri(), self.location)
+
             try:
                 subprocess.run(
                     [
@@ -282,7 +285,7 @@ class ExternalModule:
                         "1",
                         "--branch",
                         self.ref,
-                        self.location,
+                        source_dir,
                         module_dir,
                     ],
                     check=True,

--- a/blarg
+++ b/blarg
@@ -88,7 +88,7 @@ find_target() {
 }
 
 satisfy() {
-    local full_target_path script_basename target_result final_result
+    local full_target_path script_basename module_dir target_result final_result
 
     final_result=0
     for script_basename in "$@"; do
@@ -96,7 +96,9 @@ satisfy() {
         full_target_path="$(find_target "${script_basename}")" \\
             || panic "Target does not exist: ${script_basename}"
 
-        BLARG_MODULE_DIR="$(get_module_dir "${script_basename}")" \\
+        module_dir="$(get_module_dir "${script_basename}")"
+        BLARG_MODULE_DIR="${module_dir}" \\
+            BLARG_TARGETS_DIR="${module_dir}/targets" \\
             "${full_target_path}"
 
         target_result=$?

--- a/blarg
+++ b/blarg
@@ -50,7 +50,7 @@ is_external_module_target() {
 }
 
 get_module_dir() {
-    local script_basename="${1}"
+    local script_basename="${1}" module_name module_env
     if is_external_module_target "${script_basename}"; then
         module_name="${BASH_REMATCH[1]}"
         module_env="BLARG_MODULE_${module_name}"

--- a/blarg
+++ b/blarg
@@ -68,7 +68,7 @@ find_target() {
         module_name="${BASH_REMATCH[1]}"
         script_basename="${BASH_REMATCH[2]}"
         module_env="BLARG_MODULE_${module_name}"
-        search_dirs=("${!module_env}")
+        search_dirs=("${!module_env}/targets")
     else
         this_dir="$(dirname "${BLARG_TARGET_PATH}")" || panic "unable to get directory name"
         search_dirs=(

--- a/blarg
+++ b/blarg
@@ -265,10 +265,14 @@ class ExternalModule:
     ref: str
 
     def init(self, working_dir: Path) -> Path:
-        module_dir = working_dir / ".blarg" / "modules" / self.id / self.ref
-        module_dir.mkdir(parents=True, exist_ok=True)
+        # `self.ref` could have some dangerous characters in it for file paths. let's
+        # instead use a sha1 hash of `self.ref` when figuring out where to store this
+        # external module locally.
+        ref_dir_name = hashlib.sha1(self.ref.encode("utf8")).hexdigest()[:12]
+        module_dir = working_dir / ".blarg" / "modules" / self.id / ref_dir_name
 
         if not (module_dir / ".git").exists():
+            module_dir.mkdir(parents=True, exist_ok=True)
             try:
                 subprocess.run(
                     [
@@ -315,7 +319,7 @@ def parse_config(config_path: Path) -> BlargConfig:
             ExternalModule(
                 module_id,
                 config[section]["location"],
-                config[section]["ref"],  # TODO: restrict valid chars like `/`
+                config[section]["ref"],
             )
         )
     return BlargConfig(modules)

--- a/tests/all_tests.bats
+++ b/tests/all_tests.bats
@@ -397,6 +397,8 @@ BLARG_CWD=/tmp/blarg-test\..{6}
 BLARG_MODULE_DIR=/tmp/blarg-test\..{6}/\.blarg/modules/some_module/v1
 BLARG_MODULE_some_module=/tmp/blarg-test\..{6}/\.blarg/modules/some_module/v1
 .*
+BLARG_TARGETS_DIR=/tmp/blarg-test\..{6}/\.blarg/modules/some_module/v1/targets
+.*
 BLARG_TARGET_PATH=/tmp/blarg-test\..{6}/\.blarg/modules/some_module/v1/targets/print_env\.bash
 .*
 Done!$'

--- a/tests/all_tests.bats
+++ b/tests/all_tests.bats
@@ -160,6 +160,7 @@ hello, there\.\.\.
         cat <<EOF
 ^BLARG_CWD=/tmp/blarg-test\.[[:alnum:]]+
 BLARG_INDENT=-->[[:space:]]
+BLARG_MODULE_DIR=/tmp/blarg-test\.[[:alnum:]]+
 BLARG_RUNNING_TARGETS=\["/tmp/blarg-test\.[[:alnum:]]+/targets/print_env\.bash"]
 BLARG_RUN_DIR=/tmp/[[:print:]]+
 BLARG_TARGETS_DIR=/tmp/blarg-test\.[[:alnum:]]+/targets
@@ -392,6 +393,7 @@ EOF
     assert_stdout '^foobar!
 BLARG_CWD=/tmp/blarg-test\..{6}
 .*
+BLARG_MODULE_DIR=/tmp/blarg-test\..{6}/\.blarg/modules/some_module/v1
 BLARG_MODULE_some_module=/tmp/blarg-test\..{6}/\.blarg/modules/some_module/v1
 .*
 BLARG_TARGET_PATH=/tmp/blarg-test\..{6}/\.blarg/modules/some_module/v1/print_env\.bash

--- a/tests/all_tests.bats
+++ b/tests/all_tests.bats
@@ -404,3 +404,28 @@ BLARG_TARGET_PATH=/tmp/blarg-test\..{6}/\.blarg/modules/some_module/v1/targets/p
 Done!$'
     assert_exit_code 0
 }
+
+@test 'config - invalid module name - error' {
+    use_target foobar
+
+    invalid_names=(
+        "invalid/module"
+        "INVALID_MODULE"
+        "invalid-module"
+        "@invalid_module"
+        'invalid\module'
+        "invalid module"
+        "invalid.module"
+    )
+    for name in "${invalid_names[@]}"; do
+        cat >blarg.conf <<EOF
+[module.${name}]
+location = file:///does/not/matter.git
+ref = v1
+EOF
+        capture_output blarg ./targets/foobar.bash
+        assert_exit_code 1
+        assert_no_stdout
+        assert_stderr 'ValueError: Invalid module ID'
+    done
+}

--- a/tests/all_tests.bats
+++ b/tests/all_tests.bats
@@ -536,3 +536,6 @@ EOF
     assert_exit_code 0
     assert_stdout '^hello from b!$'
 }
+
+# TODO: test when module is referenced in target, but not config file
+# TODO: test when remote module repo doesn't exist

--- a/tests/all_tests.bats
+++ b/tests/all_tests.bats
@@ -378,7 +378,8 @@ dry-run: would apply run_once_b$'
 
     module_path="${TEST_HOME}/some_module"
     init_git_repo "${module_path}"
-    mv "${TEST_CWD}/targets/print_env.bash" "${TEST_CWD}/targets/foobar.bash" "${module_path}"
+    mkdir "${module_path}/targets"
+    mv "${TEST_CWD}/targets/print_env.bash" "${TEST_CWD}/targets/foobar.bash" "${module_path}/targets"
     git -C "${module_path}" add .
     git -C "${module_path}" commit -m "initial commit"
     git -C "${module_path}" tag v1
@@ -389,14 +390,14 @@ location = file://${module_path}/.git
 ref = v1
 EOF
     capture_output blarg ./targets/external_module.bash
-    assert_stderr '^Cloning into .+\.blarg/modules/some_module/v1.+$'
+    assert_stderr '^Cloning into '"'"'/tmp/blarg-test\..{6}/\.blarg/modules/some_module/v1'"'"'\.\.\.$'
     assert_stdout '^foobar!
 BLARG_CWD=/tmp/blarg-test\..{6}
 .*
 BLARG_MODULE_DIR=/tmp/blarg-test\..{6}/\.blarg/modules/some_module/v1
 BLARG_MODULE_some_module=/tmp/blarg-test\..{6}/\.blarg/modules/some_module/v1
 .*
-BLARG_TARGET_PATH=/tmp/blarg-test\..{6}/\.blarg/modules/some_module/v1/print_env\.bash
+BLARG_TARGET_PATH=/tmp/blarg-test\..{6}/\.blarg/modules/some_module/v1/targets/print_env\.bash
 .*
 Done!$'
     assert_exit_code 0

--- a/tests/all_tests.bats
+++ b/tests/all_tests.bats
@@ -413,6 +413,27 @@ Done!$'
     assert_exit_code 0
 }
 
+@test 'depends_on - tilde in external module path - expands to home' {
+    use_target external_module print_env foobar
+
+    module_path="${TEST_HOME}/some_module"
+    init_git_repo "${module_path}"
+    mkdir "${module_path}/targets"
+    mv "${TEST_CWD}/targets/print_env.bash" "${TEST_CWD}/targets/foobar.bash" "${module_path}/targets"
+    git -C "${module_path}" add .
+    git -C "${module_path}" commit -m "initial commit"
+    git -C "${module_path}" tag v1
+
+    cat >blarg.conf <<EOF
+[module.some_module]
+location = file://~/some_module/.git
+ref = v1
+EOF
+    capture_output blarg ./targets/external_module.bash
+    assert_stderr "^Cloning into '/tmp/blarg-test\\..{6}/\\.blarg/modules/some_module/5a6df720540c'\\.\\.\\.\$"
+    assert_exit_code 0
+}
+
 @test 'config - invalid module name - error' {
     use_target foobar
 

--- a/tests/all_tests.bats
+++ b/tests/all_tests.bats
@@ -391,9 +391,8 @@ ref = v1
 EOF
     capture_output blarg ./targets/external_module.bash
 
-    # TODO: ensure clone doesn't happen a second time
-    assert_stderr '^Cloning into '"'"'/tmp/blarg-test\..{6}/\.blarg/modules/some_module/5a6df720540c'"'"'\.\.\.$'
-    assert_stdout '^foobar!
+    assert_stderr "^Cloning into '/tmp/blarg-test\\..{6}/\\.blarg/modules/some_module/5a6df720540c'\\.\\.\\.\$"
+    expected_stdout='^foobar!
 BLARG_CWD=/tmp/blarg-test\..{6}
 .*
 BLARG_MODULE_DIR=/tmp/blarg-test\..{6}/\.blarg/modules/some_module/5a6df720540c
@@ -404,6 +403,13 @@ BLARG_TARGETS_DIR=/tmp/blarg-test\..{6}/\.blarg/modules/some_module/5a6df720540c
 BLARG_TARGET_PATH=/tmp/blarg-test\..{6}/\.blarg/modules/some_module/5a6df720540c/targets/print_env\.bash
 .*
 Done!$'
+    assert_stdout "${expected_stdout}"
+    assert_exit_code 0
+
+    # do it again, but this time there should be no git clone
+    capture_output blarg ./targets/external_module.bash
+    assert_no_stderr
+    assert_stdout "${expected_stdout}"
     assert_exit_code 0
 }
 

--- a/tests/all_tests.bats
+++ b/tests/all_tests.bats
@@ -390,16 +390,16 @@ location = file://${module_path}/.git
 ref = v1
 EOF
     capture_output blarg ./targets/external_module.bash
-    assert_stderr '^Cloning into '"'"'/tmp/blarg-test\..{6}/\.blarg/modules/some_module/v1'"'"'\.\.\.$'
+    assert_stderr '^Cloning into '"'"'/tmp/blarg-test\..{6}/\.blarg/modules/some_module/5a6df720540c'"'"'\.\.\.$'
     assert_stdout '^foobar!
 BLARG_CWD=/tmp/blarg-test\..{6}
 .*
-BLARG_MODULE_DIR=/tmp/blarg-test\..{6}/\.blarg/modules/some_module/v1
-BLARG_MODULE_some_module=/tmp/blarg-test\..{6}/\.blarg/modules/some_module/v1
+BLARG_MODULE_DIR=/tmp/blarg-test\..{6}/\.blarg/modules/some_module/5a6df720540c
+BLARG_MODULE_some_module=/tmp/blarg-test\..{6}/\.blarg/modules/some_module/5a6df720540c
 .*
-BLARG_TARGETS_DIR=/tmp/blarg-test\..{6}/\.blarg/modules/some_module/v1/targets
+BLARG_TARGETS_DIR=/tmp/blarg-test\..{6}/\.blarg/modules/some_module/5a6df720540c/targets
 .*
-BLARG_TARGET_PATH=/tmp/blarg-test\..{6}/\.blarg/modules/some_module/v1/targets/print_env\.bash
+BLARG_TARGET_PATH=/tmp/blarg-test\..{6}/\.blarg/modules/some_module/5a6df720540c/targets/print_env\.bash
 .*
 Done!$'
     assert_exit_code 0

--- a/tests/targets/external_module.bash
+++ b/tests/targets/external_module.bash
@@ -1,0 +1,8 @@
+#!/usr/bin/env blarg
+
+depends_on @some_module:foobar
+
+apply() {
+    satisfy @some_module:print_env
+    echo "Done!"
+}

--- a/tests/util.sh
+++ b/tests/util.sh
@@ -39,6 +39,15 @@ use_lib() {
     cp -r "${REPO_HOME}/tests/lib.d" "${TEST_CWD}"
 }
 
+init_git_repo() {
+    repo_path="${1}"
+    git config --global init.defaultBranch main
+    git config --global advice.detachedHead false
+    git config --global user.email "nope@example.com"
+    git config --global user.name "nope"
+    git init "${repo_path}"
+}
+
 # shellcheck disable=SC2034  # this function returns data via variables
 capture_output() {
     local stderr_file stdout_file


### PR DESCRIPTION
adds a config file that can specify external modules, for example:

```ini
# in blarg.conf
[module.pcrockett]
location = https://github.com/pcrockett/blarg-targets.git
ref = v1
```

this allows us to now specify external dependencies when writing our own targets, for example:

```bash
depends_on @pcrockett:foobar

apply() {
  satisfy @pcrockett:whatever
  # do stuff here
  echo "Done!"
}
```

**not yet:**

this does not yet allow us to run external targets directly from the CLI, but i think that is step 2. in a followup PR i'd like to make it so we can run something like this:

```bash
blarg --module https://github.com/pcrockett/blarg-targets.git?ref=v1 foobar
```

this would be super handy for bootstrapping new machines, for example.